### PR TITLE
chore: Update dev-dependencies and @angular/material and cdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   },
   "dependencies": {
     "@angular/animations": "^4.1.0",
+    "@angular/material": "^2.0.0-beta.8",
+    "@angular/cdk": "^2.0.0-beta.8",
     "@angular/common": "^4.1.0",
     "@angular/compiler": "^4.1.0",
     "@angular/core": "^4.1.0",
@@ -32,23 +34,23 @@
     "zone.js": "^0.8.4"
   },
   "devDependencies": {
-    "@angular/cli": "1.0.3",
+    "@angular/cli": "1.2.3",
     "@angular/compiler-cli": "^4.1.0",
-    "@types/jasmine": "2.5.38",
+    "@types/jasmine": "2.5.53",
     "@types/node": "~6.0.60",
     "angular-cli-ghpages": "^0.5.0",
-    "codelyzer": "~2.0.0",
-    "jasmine-core": "~2.5.2",
-    "jasmine-spec-reporter": "~3.2.0",
-    "karma": "~1.4.1",
-    "karma-chrome-launcher": "~2.0.0",
+    "codelyzer": "~3.0.1",
+    "jasmine-core": "~2.6.2",
+    "jasmine-spec-reporter": "~4.1.0",
+    "karma": "~1.7.0",
+    "karma-chrome-launcher": "~2.1.1",
     "karma-cli": "~1.0.1",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "karma-coverage-istanbul-reporter": "^0.2.0",
+    "karma-coverage-istanbul-reporter": "^1.2.1",
     "protractor": "~5.1.0",
-    "ts-node": "~2.0.0",
-    "tslint": "~4.5.0",
-    "typescript": "~2.2.0"
+    "ts-node": "~3.0.4",
+    "tslint": "~5.3.2",
+    "typescript": "~2.3.3"
   }
 }


### PR DESCRIPTION
Update dependencies for avoid webpack error.

The same reason that https://github.com/nsmolenskii/ng-demo-lib/pull/6.